### PR TITLE
Made File Executable By Adding Python3 Shebang

### DIFF
--- a/celltics/tools/vargroup.py
+++ b/celltics/tools/vargroup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 (c) MGH Center for Integrated Diagnostics
 


### PR DESCRIPTION
Added Python3 Shebang on top of vargroup.py. Should be able to make vargroup.py executable. 